### PR TITLE
fixed wrong operation status

### DIFF
--- a/catalystwan/utils/operation_status.py
+++ b/catalystwan/utils/operation_status.py
@@ -6,7 +6,7 @@ class OperationStatus(Enum):
     FAILURE = "Failure"
     SUCCESS = "Success"
     SCHEDULED = "Scheduled"
-    DONE_SCHEDULED = "Done - Scheduled"
+    SUCCESS_SCHEDULED = "Done - Scheduled"
     VALIDATION_SUCCESS = "Validation success"
     VALIDATION_FAILURE = "Validation failure"
 
@@ -16,5 +16,5 @@ class OperationStatusId(Enum):
     FAILURE = "failure"
     SUCCESS = "success"
     SCHEDULED = "scheduled"
-    DONE_SCHEDULED = "done_scheduled"
+    SUCCESS_SCHEDULED = "success_scheduled"
     VALIDATION_SUCCESS = "validation_success"


### PR DESCRIPTION
SD-WAN Manager status is "success_scheduled" not, "done_scheduled". The previous code was causing the wait_for_completed() function to hang until max retry.


Example from SD-WAN Manager API JSON response:
```
<...>
   "data":[
      {
         "statusType":"push_feature_template_configuration",
         <...>
         "statusId":"success_scheduled",
         "currentActivity":"Device became unreachable. Configuration template edge_basic scheduled to be attached when device comes online.",
         <...>
         "status":"Done - Scheduled",
         "order":0
      }
   ],
<...>
```