### PR TITLE
fixed alias for incl_def_root_cert

### DIFF
--- a/catalystwan/api/config_device_inventory_api.py
+++ b/catalystwan/api/config_device_inventory_api.py
@@ -49,7 +49,7 @@ class ConfigurationDeviceInventoryAPI:
         Returns handy model of generated bootstrap config
         """
         params = GenerateBoostrapConfigurationQueryParams(
-            configtype=configtype, incl_def_root_cert=incl_def_root_cert, version=version
+            configtype=configtype, inclDefRootCert=incl_def_root_cert, version=version
         )
         reponse = self.endpoint.generate_bootstrap_configuration(uuid=device_uuid, params=params)
 

--- a/catalystwan/endpoints/configuration_device_inventory.py
+++ b/catalystwan/endpoints/configuration_device_inventory.py
@@ -172,7 +172,7 @@ class ConfigType(str, Enum):
 
 class GenerateBoostrapConfigurationQueryParams(BaseModel):
     configtype: Optional[ConfigType] = Field(default=ConfigType.CLOUDINIT)
-    incl_def_root_cert: Optional[bool] = Field(default=False)
+    incl_def_root_cert: Optional[bool] = Field(default=False, alias="inclDefRootCert")
     version: Optional[str] = Field(default="v1")
 
 


### PR DESCRIPTION
With current code, the bootstrap is always generated with default root cert as parameter passed in API call uses wrong name. After this fix, device_inventory.generate_bootstrap_configuration(uuid).bootstrap_config returns expected output which doesn't include default root ca.