### PR TITLE
session state handling improvements

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,4 +4,4 @@
 # These owners will be the default owners for everything in
 # the repo. Unless a later match takes precedence
 
-*       @kagrski @JimOverholt @igosoft @sbasan @bboot2
+*       @kagrski @JimOverholt @igosoft @sbasan @bboot2 @jkrajew

--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ with create_manager_session(url=url, username=username, password=password, subdo
 
 
 ## API usage examples
-All examples below assumes `session` contains logged-in [ManagerSession](#Manager-Session)
+All examples below assumes `session` variable contains logged-in [Manager Session](#Manager-Session) instance.
 
 <details>
     <summary> <b>Get devices</b> <i>(click to expand)</i></summary>

--- a/README.md
+++ b/README.md
@@ -11,27 +11,89 @@ Cisco Catalyst WAN SDK is a package for creating simple and parallel automatic r
 pip install catalystwan
 ```
 
-## Session usage example
-Our session is an extension to `requests.Session` designed to make it easier to communicate via API calls with SDWAN Manager. We provide ready to use authentication, you have to simply provide the Manager url, username and password as as if you were doing it through a GUI. 
+## Manager Session
+In order to execute SDK APIs **ManagerSession** needs to be created. The fastest way to get started is to use `create_manager_session()` method which configures session, performs authentication for given credentials and returns **ManagerSession** instance in operational state. **ManagerSession** provides a collection of supported APIs in `api` instance variable.
+Please check example below:
+
 ```python
 from catalystwan.session import create_manager_session
+
+url = "sandbox-sdwan-2.cisco.com"
+username = "devnetuser"
+password = "RG!_Yw919_83"
+
+with create_manager_session(url=url, username=username, password=password) as session:
+    devices = session.api.devices.get()
+    print(devices)
+```
+**ManagerSession** extends [requests.Session](https://requests.readthedocs.io/en/latest/user/advanced/#session-objects) so all functionality from [requests](https://requests.readthedocs.io/en/latest/) library is avaiable to user, it also implements python [contextmanager](https://docs.python.org/3.8/library/contextlib.html#contextlib.contextmanager) and automatically frees server resources on exit.
+
+<details>
+    <summary> <b>Configure Manager Session before using</b> <i>(click to expand)</i></summary>
+
+It is possible to configure **ManagerSession** prior sending any request.
+
+```python
+from catalystwan.session import ManagerSession
 
 url = "example.com"
 username = "admin"
 password = "password123"
-with create_manager_session(url=url, username=username, password=password) as session:
-    session.get("/dataservice/device")
 
-# When interacting with the SDWAN Manager API without using a context manager, it's important 
-# to manually execute the `close()` method to release the user session resource.
-
-session = create_manager_session(url=url, username=username, password=password)
+# configure session using constructor - nothing will be sent to target server yet
+session = ManagerSession(url=url, username=username, password=password)
+# login and send requests
+session.login()
 session.get("/dataservice/device")
 session.close()
 ```
+When interacting with the SDWAN Manager API without using a context manager, it's important 
+to manually execute the `close()` method to release the user session resource.
 Ensure that the `close()` method is called after you have finished using the session to maintain optimal resource management and avoid potential errors.
 
+</details>
+
+<details>
+    <summary> <b>Login as Tenant</b> <i>(click to expand)</i></summary>
+
+Tenant domain needs to be provided in url together with Tenant credentials.
+
+```python
+from catalystwan.session import create_manager_session
+
+url = "tenant.example.com"
+username = "tenant_user"
+password = "password123"
+
+with create_manager_session(url=url, username=username, password=password) as session:
+    print(session.session_type)
+```
+
+</details>
+
+<details>
+    <summary> <b>Login as Provider-as-Tenant</b> <i>(click to expand)</i></summary>
+
+Tenant `subdomain` needs to be provided as additional argument together with Provider credentials.
+
+```python
+from catalystwan.session import create_manager_session
+
+url = "example.com"
+username = "provider"
+password = "password123"
+subdomain = "tenant.example.com"
+
+with create_manager_session(url=url, username=username, password=password, subdomain=subdomain) as session:
+    print(session.session_type)
+```
+
+</details>
+
+
+
 ## API usage examples
+All examples below assumes `session` contains logged-in [ManagerSession](#Manager-Session)
 
 <details>
     <summary> <b>Get devices</b> <i>(click to expand)</i></summary>

--- a/catalystwan/__init__.py
+++ b/catalystwan/__init__.py
@@ -13,6 +13,8 @@ from typing import Callable, Final, List, Optional
 
 import urllib3
 
+USER_AGENT = f"{__package__}/{metadata.version(__package__)}"
+
 
 def with_proc_info_header(method: Callable[..., str]) -> Callable[..., str]:
     """

--- a/catalystwan/exceptions.py
+++ b/catalystwan/exceptions.py
@@ -171,7 +171,7 @@ class TenantMigrationPreconditionsError(CatalystwanException):
 
 
 class ManagerReadyTimeout(CatalystwanException):
-    """Raised when wainting for server ready flag took longer than expected"""
+    """Raised when waiting for server ready flag took longer than expected"""
 
     pass
 

--- a/catalystwan/exceptions.py
+++ b/catalystwan/exceptions.py
@@ -170,6 +170,12 @@ class TenantMigrationPreconditionsError(CatalystwanException):
     pass
 
 
+class ManagerReadyTimeout(CatalystwanException):
+    """Raised when wainting for server ready flag took longer than expected"""
+
+    pass
+
+
 class CatalystwanDeprecationWarning(DeprecationWarning):
     """Warning issued when using deprecated features or functionality in the Catalystwan SDK.
 

--- a/catalystwan/response.py
+++ b/catalystwan/response.py
@@ -1,6 +1,8 @@
 # Copyright 2023 Cisco Systems, Inc. and its affiliates
 
 import re
+from datetime import datetime
+from email.utils import parsedate_to_datetime
 from functools import wraps
 from pprint import pformat
 from typing import Any, Callable, Dict, Optional, Sequence, Type, TypeVar, Union, cast
@@ -136,14 +138,25 @@ class ManagerResponse(Response, APIEndpointClientResponse):
 
     def __init__(self, response: Response):
         self.__dict__.update(response.__dict__)
-        if not self.cookies.keys():
-            self.cookies = self.__parse_set_cookie_from_headers()
+        self.jsessionid_expired = self._detect_expired_jsessionid()
         try:
             self.payload = JsonPayload(response.json())
         except JSONDecodeError:
             self.payload = JsonPayload()
 
-    def __parse_set_cookie_from_headers(self) -> RequestsCookieJar:
+    def _detect_expired_jsessionid(self) -> bool:
+        """Determines if server sent expired JSESSIONID"""
+        cookies = self._parse_set_cookie_from_headers()
+        if (expires := cookies.get("Expires")) and cookies.get("JSESSIONID"):
+            # get current server time, when not present use local time
+            # local time might be innacurate but "Expires" is usually set to year 1970
+            response_date = self.headers.get("date")
+            compare_date = parsedate_to_datetime(response_date) if response_date is not None else datetime.now()
+            if parsedate_to_datetime(expires) <= compare_date:
+                return True
+        return False
+
+    def _parse_set_cookie_from_headers(self) -> RequestsCookieJar:
         """Parses "set-cookie" content from response headers"""
         jar = RequestsCookieJar()
         cookies_string = self.headers.get("set-cookie", "")

--- a/catalystwan/tests/test_session.py
+++ b/catalystwan/tests/test_session.py
@@ -3,6 +3,7 @@
 import unittest
 from typing import Optional
 from unittest.mock import patch
+from uuid import uuid4
 
 import pytest  # type: ignore
 from parameterized import parameterized  # type: ignore
@@ -17,7 +18,7 @@ class TestSession(unittest.TestCase):
     def setUp(self):
         self.url = "example.com"
         self.username = "admin"
-        self.password = "admin_password"  # pragma: allowlist secret
+        self.password = str(uuid4())
 
     def test_session_str(self):
         # Arrange, Act

--- a/catalystwan/tests/test_vmanage_auth.py
+++ b/catalystwan/tests/test_vmanage_auth.py
@@ -2,9 +2,11 @@
 
 import unittest
 from unittest import TestCase, mock
+from uuid import uuid4
 
 from requests import Request
 
+from catalystwan import USER_AGENT
 from catalystwan.vmanage_auth import UnauthorizedAccessError, vManageAuth
 
 
@@ -45,7 +47,7 @@ def mocked_requests_method(*args, **kwargs):
 class TestvManageAuth(TestCase):
     def setUp(self):
         self.base_url = "https://1.1.1.1:1111"
-        self.password = "admin"  # pragma: allowlist secret
+        self.password = str(uuid4())
 
     @mock.patch("requests.post", side_effect=mocked_requests_method)
     def test_get_cookie(self, mock_post):
@@ -53,7 +55,7 @@ class TestvManageAuth(TestCase):
         username = "admin"
         security_payload = {
             "j_username": username,
-            "j_password": "admin",  # pragma: allowlist secret
+            "j_password": self.password,
         }
         auth = vManageAuth(self.base_url, username, self.password)
         # Act
@@ -64,7 +66,7 @@ class TestvManageAuth(TestCase):
             url="https://1.1.1.1:1111/j_security_check",
             data=security_payload,
             verify=False,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            headers={"Content-Type": "application/x-www-form-urlencoded", "User-Agent": USER_AGENT},
         )
 
     @mock.patch("requests.post", side_effect=mocked_requests_method)
@@ -73,7 +75,7 @@ class TestvManageAuth(TestCase):
         username = "invalid_username"
         security_payload = {
             "j_username": username,
-            "j_password": "admin",  # pragma: allowlist secret
+            "j_password": self.password,
         }
         auth = vManageAuth(self.base_url, username, self.password)
         # Act
@@ -85,7 +87,7 @@ class TestvManageAuth(TestCase):
             url="https://1.1.1.1:1111/j_security_check",
             data=security_payload,
             verify=False,
-            headers={"Content-Type": "application/x-www-form-urlencoded"},
+            headers={"Content-Type": "application/x-www-form-urlencoded", "User-Agent": USER_AGENT},
         )
 
     @mock.patch("requests.cookies.RequestsCookieJar")
@@ -102,7 +104,7 @@ class TestvManageAuth(TestCase):
         mock_get.assert_called_with(
             url=valid_url,
             verify=False,
-            headers={"Content-Type": "application/json"},
+            headers={"Content-Type": "application/json", "User-Agent": USER_AGENT},
             cookies=cookies,
         )
 

--- a/catalystwan/vmanage_auth.py
+++ b/catalystwan/vmanage_auth.py
@@ -9,7 +9,7 @@ from requests import PreparedRequest, Response
 from requests.auth import AuthBase
 from requests.cookies import RequestsCookieJar
 
-from catalystwan import with_proc_info_header
+from catalystwan import USER_AGENT, with_proc_info_header
 from catalystwan.exceptions import CatalystwanException
 
 
@@ -85,7 +85,7 @@ class vManageAuth(AuthBase):
             "j_password": self.password,
         }
         full_url = urljoin(self.base_url, "/j_security_check")
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        headers = {"Content-Type": "application/x-www-form-urlencoded", "User-Agent": USER_AGENT}
         response = requests.post(
             url=full_url,
             data=security_payload,
@@ -110,7 +110,7 @@ class vManageAuth(AuthBase):
             str: Valid token.
         """
         full_url = urljoin(self.base_url, "/dataservice/client/token")
-        headers = {"Content-Type": "application/json"}
+        headers = {"Content-Type": "application/json", "User-Agent": USER_AGENT}
         response = requests.get(
             url=full_url,
             cookies=cookies,


### PR DESCRIPTION
# Pull Request summary:
- [x] Fix session expiration detection for re-login. It wasn't working properly for recent 20.15 builds with Analytics enabled (additional cookies are being stored by SDWAN Manager)
- [x] Fix: requests which are sent from SDK but not from `ManagerSession` (like auth or server ready polling) are also correctly including custom "User-Agent" in headers.
- [x] Introduce `restart_imminent()` method and internal state handling which detects restart condition, waits for server ready and performs automatic re-login.
- [x] Update `README.md` clarify session role in SDK. Add tenant and provider-as-tenant login examples.

# Description of changes:
[Add more in depth analysis of what changed, provide logs, examples of usage]

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
