### PR TITLE
Add get_device_template method, remove dont use device model enum, th…

### DIFF
--- a/catalystwan/api/template_api.py
+++ b/catalystwan/api/template_api.py
@@ -746,3 +746,8 @@ class TemplatesAPI:
         params = {"feature": "all"}
         templates = self.session.get(url=endpoint, params=params)
         return templates.dataseq(DeviceTemplateInformation)
+
+    def get_device_template(self, template_id: str) -> DeviceTemplate:
+        endpoint = f"/dataservice/template/device/object/{template_id}"
+        response = self.session.get(endpoint)
+        return DeviceTemplate(**response.json())

--- a/catalystwan/api/templates/device_template/device_template.py
+++ b/catalystwan/api/templates/device_template/device_template.py
@@ -9,8 +9,6 @@ from typing import TYPE_CHECKING, Final, List
 from jinja2 import DebugUndefined, Environment, FileSystemLoader, meta  # type: ignore
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
-from catalystwan.utils.device_model import DeviceModel
-
 if TYPE_CHECKING:
     from catalystwan.session import ManagerSession
 
@@ -46,9 +44,9 @@ class DeviceTemplate(BaseModel):
 
     template_name: str = Field(alias="templateName")
     template_description: str = Field(alias="templateDescription")
-    general_templates: List[GeneralTemplate] = Field(alias="generalTemplates")
+    general_templates: List[GeneralTemplate] = Field(default=[], alias="generalTemplates")
     device_role: str = Field(default="sdwan-edge", alias="deviceRole")
-    device_type: DeviceModel = Field(alias="deviceType")
+    device_type: str = Field(alias="deviceType")
     security_policy_id: str = Field(default="", alias="securityPolicyId")
     policy_id: str = Field(default="", alias="policyId")
 

--- a/catalystwan/models/configuration/config_migration.py
+++ b/catalystwan/models/configuration/config_migration.py
@@ -5,7 +5,8 @@ from typing import List, Literal, Union
 from pydantic import BaseModel, ConfigDict, Field
 from typing_extensions import Annotated
 
-from catalystwan.api.template_api import DeviceTemplateInformation, FeatureTemplateInformation
+from catalystwan.api.template_api import FeatureTemplateInformation
+from catalystwan.api.templates.device_template.device_template import DeviceTemplate
 from catalystwan.endpoints.configuration_group import ConfigGroup
 from catalystwan.models.configuration.feature_profile.common import FeatureProfileCreationPayload
 from catalystwan.models.configuration.feature_profile.sdwan.policy_object import AnyPolicyObjectParcel
@@ -51,7 +52,7 @@ class UX1Templates(BaseModel):
     feature_templates: List[FeatureTemplateInformation] = Field(
         default=[], serialization_alias="featureTemplates", validation_alias="featureTemplates"
     )
-    device_templates: List[DeviceTemplateInformation] = Field(
+    device_templates: List[DeviceTemplate] = Field(
         default=[], serialization_alias="deviceTemplates", validation_alias="deviceTemplates"
     )
 

--- a/catalystwan/workflows/config_migration.py
+++ b/catalystwan/workflows/config_migration.py
@@ -92,10 +92,12 @@ def collect_ux1_config(session: ManagerSession, progress: Callable[[str, int, in
     progress("Collecting Templates Info", 0, 2)
 
     ux1.templates.feature_templates = [t for t in template_api.get_feature_templates()]
-    progress("Collecting Templates Info", 1, 2)
+    progress("Collecting Feature Templates", 1, 2)
 
-    ux1.templates.device_templates = [t for t in template_api.get_device_templates()]
-    progress("Collecting Templates Info", 2, 2)
+    device_templates_ids = [t.id for t in template_api.get_device_templates()]
+    for i, dtid in enumerate(device_templates_ids):
+        ux1.templates.device_templates.append(template_api.get_device_template(dtid))
+        progress("Collecting Device Templates", i + 1, len(device_templates_ids))
 
     return ux1
 


### PR DESCRIPTION
# Pull Request summary:
Add get_device_template method, remove dont use device model enum, there are too many modeles to cover and that could couse problems. Change logging information to be more descriptive

# Description of changes:
[Add more in depth analysis of what changed, provide logs, examples of usage]

# Checklist:
- [X] Make sure to run pre-commit before committing changes
- [X] Make sure all checks have passed
- [X] PR description is clear and comprehensive
- [X] Mentioned the issue that this PR solves (if applicable)
- [X] Make sure you test the changes
