### PR TITLE
add policy-list to policy-object-parcel converters

### DIFF
--- a/catalystwan/api/feature_profile_api.py
+++ b/catalystwan/api/feature_profile_api.py
@@ -41,7 +41,7 @@ from catalystwan.models.configuration.feature_profile.sdwan.policy_object import
     IPv6DataPrefixParcel,
     IPv6PrefixListParcel,
     LocalDomainParcel,
-    PolicierParcel,
+    PolicerParcel,
     PreferredColorGroupParcel,
     PrefixListParcel,
     ProtocolListParcel,
@@ -655,7 +655,7 @@ class PolicyObjectFeatureProfileAPI:
         ...
 
     @overload
-    def get(self, profile_id: UUID, parcel_type: Type[PolicierParcel]) -> DataSequence[Parcel[Any]]:
+    def get(self, profile_id: UUID, parcel_type: Type[PolicerParcel]) -> DataSequence[Parcel[Any]]:
         ...
 
     @overload
@@ -767,7 +767,7 @@ class PolicyObjectFeatureProfileAPI:
         ...
 
     @overload
-    def get(self, profile_id: UUID, parcel_type: Type[PolicierParcel], parcel_id: UUID) -> DataSequence[Parcel[Any]]:
+    def get(self, profile_id: UUID, parcel_type: Type[PolicerParcel], parcel_id: UUID) -> DataSequence[Parcel[Any]]:
         ...
 
     @overload
@@ -915,7 +915,7 @@ class PolicyObjectFeatureProfileAPI:
         ...
 
     @overload
-    def delete(self, profile_id: UUID, parcel_type: Type[PolicierParcel], list_object_id: UUID) -> None:
+    def delete(self, profile_id: UUID, parcel_type: Type[PolicerParcel], list_object_id: UUID) -> None:
         ...
 
     @overload

--- a/catalystwan/models/configuration/config_migration.py
+++ b/catalystwan/models/configuration/config_migration.py
@@ -12,13 +12,10 @@ from catalystwan.models.configuration.feature_profile.common import FeatureProfi
 from catalystwan.models.configuration.feature_profile.sdwan.policy_object import AnyPolicyObjectParcel
 from catalystwan.models.configuration.feature_profile.sdwan.system import AnySystemParcel
 from catalystwan.models.configuration.topology_group import TopologyGroup
-from catalystwan.models.policy import (
-    AnyPolicyDefinition,
-    AnyPolicyList,
-    CentralizedPolicy,
-    LocalizedPolicy,
-    SecurityPolicy,
-)
+from catalystwan.models.policy import AnyPolicyDefinition, AnyPolicyList
+from catalystwan.models.policy.centralized import CentralizedPolicyInfo
+from catalystwan.models.policy.localized import LocalizedPolicyInfo
+from catalystwan.models.policy.security import AnySecurityPolicyInfo
 
 AnyParcel = Annotated[
     Union[
@@ -31,13 +28,13 @@ AnyParcel = Annotated[
 
 class UX1Policies(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
-    centralized_policies: List[CentralizedPolicy] = Field(
+    centralized_policies: List[CentralizedPolicyInfo] = Field(
         default=[], serialization_alias="centralizedPolicies", validation_alias="centralizedPolicies"
     )
-    localized_policies: List[LocalizedPolicy] = Field(
+    localized_policies: List[LocalizedPolicyInfo] = Field(
         default=[], serialization_alias="localizedPolicies", validation_alias="localizedPolicies"
     )
-    security_policies: List[SecurityPolicy] = Field(
+    security_policies: List[AnySecurityPolicyInfo] = Field(
         default=[], serialization_alias="securityPolicies", validation_alias="securityPolicies"
     )
     policy_definitions: List[AnyPolicyDefinition] = Field(

--- a/catalystwan/models/configuration/feature_profile/sdwan/policy_object/__init__.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/policy_object/__init__.py
@@ -44,7 +44,7 @@ AnyURLParcel = Annotated[
 
 AnyPolicyObjectParcel = Annotated[
     Union[
-        # AnyURLParcel,
+        AnyURLParcel,
         ApplicationListParcel,
         AppProbeParcel,
         ColorParcel,

--- a/catalystwan/models/configuration/feature_profile/sdwan/policy_object/__init__.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/policy_object/__init__.py
@@ -13,7 +13,7 @@ from .policy.expanded_community_list import ExpandedCommunityParcel
 from .policy.fowarding_class import FowardingClassParcel, FowardingClassQueueEntry
 from .policy.ipv6_data_prefix import IPv6DataPrefixEntry, IPv6DataPrefixParcel
 from .policy.ipv6_prefix_list import IPv6PrefixListEntry, IPv6PrefixListParcel
-from .policy.policier import PolicierEntry, PolicierParcel
+from .policy.policer import PolicerEntry, PolicerParcel
 from .policy.prefered_group_color import Preference, PreferredColorGroupEntry, PreferredColorGroupParcel
 from .policy.prefix_list import PrefixListEntry, PrefixListParcel
 from .policy.sla_class import FallbackBestTunnel, SLAAppProbeClass, SLAClassCriteria, SLAClassListEntry, SLAClassParcel
@@ -57,7 +57,7 @@ AnyPolicyObjectParcel = Annotated[
         IPv6DataPrefixParcel,
         IPv6PrefixListParcel,
         LocalDomainParcel,
-        PolicierParcel,
+        PolicerParcel,
         PreferredColorGroupParcel,
         PrefixListParcel,
         ProtocolListParcel,
@@ -101,8 +101,8 @@ __all__ = (
     "IPv6PrefixListParcel",
     "LocalDomainListEntry",
     "LocalDomainParcel",
-    "PolicierEntry",
-    "PolicierParcel",
+    "PolicerEntry",
+    "PolicerParcel",
     "Preference",
     "PreferredColorGroupEntry",
     "PreferredColorGroupParcel",

--- a/catalystwan/models/configuration/feature_profile/sdwan/policy_object/policy/expanded_community_list.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/policy_object/policy/expanded_community_list.py
@@ -10,17 +10,17 @@ from catalystwan.api.configuration_groups.parcel import Global, _ParcelBase, as_
 class ExpandedCommunityParcel(_ParcelBase):
     type_: Literal["expanded-community"] = Field(default="expanded-community", exclude=True)
     model_config = ConfigDict(populate_by_name=True)
-    expandedCommunityList: Global[list] = Field(
+    expanded_community_list: Global[list] = Field(
         default=as_global([]),
         serialization_alias="expandedCommunityList",
         validation_alias=AliasPath("data", "expandedCommunityList"),
     )
 
     def add_community(self, expanded_community: str):
-        self.expandedCommunityList.value.append(expanded_community)
+        self.expanded_community_list.value.append(expanded_community)
 
-    @field_validator("expandedCommunityList")
+    @field_validator("expanded_community_list")
     @classmethod
-    def check_rate(cls, expanded_community_list: Global):
+    def check_list_str(cls, expanded_community_list: Global):
         assert all([isinstance(ec, str) for ec in expanded_community_list.value])
         return expanded_community_list

--- a/catalystwan/models/configuration/feature_profile/sdwan/policy_object/policy/ipv6_data_prefix.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/policy_object/policy/ipv6_data_prefix.py
@@ -1,6 +1,6 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 
-from ipaddress import IPv6Address, IPv6Network
+from ipaddress import IPv6Address, IPv6Interface
 from typing import List, Literal
 
 from pydantic import AliasPath, BaseModel, ConfigDict, Field
@@ -18,10 +18,10 @@ class IPv6DataPrefixParcel(_ParcelBase):
     type_: Literal["data-ipv6-prefix"] = Field(default="data-ipv6-prefix", exclude=True)
     entries: List[IPv6DataPrefixEntry] = Field(default=[], validation_alias=AliasPath("data", "entries"))
 
-    def add_prefix(self, ipv6_network: IPv6Network):
+    def add_prefix(self, ipv6_network: IPv6Interface):
         self.entries.append(
             IPv6DataPrefixEntry(
-                ipv6_address=as_global(ipv6_network.network_address),
-                ipv6_prefix_length=as_global(ipv6_network.prefixlen),
+                ipv6_address=as_global(ipv6_network.network.network_address),
+                ipv6_prefix_length=as_global(ipv6_network.network.prefixlen),
             )
         )

--- a/catalystwan/models/configuration/feature_profile/sdwan/policy_object/policy/ipv6_prefix_list.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/policy_object/policy/ipv6_prefix_list.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Cisco Systems, Inc. and its affiliates
 
-from ipaddress import IPv6Address, IPv6Network
-from typing import List, Literal
+from ipaddress import IPv6Address, IPv6Interface
+from typing import List, Literal, Optional
 
 from pydantic import AliasPath, BaseModel, ConfigDict, Field
 
@@ -11,17 +11,27 @@ from catalystwan.api.configuration_groups.parcel import Global, _ParcelBase, as_
 class IPv6PrefixListEntry(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     ipv6_address: Global[IPv6Address] = Field(serialization_alias="ipv6Address", validation_alias="ipv6Address")
-    ipv6_prefix_length: Global[int] = Field(serialization_alias="ipv6PrefixLength", validation_alias="ipv6PrefixLength")
+    ipv6_prefix_length: Global[int] = Field(
+        serialization_alias="ipv6PrefixLength", validation_alias="ipv6PrefixLength", ge=0, le=128
+    )
+    le_range_prefix_length: Optional[Global[int]] = Field(
+        serialization_alias="leRangePrefixLength", validation_alias="leRangePrefixLength"
+    )
+    ge_range_prefix_length: Optional[Global[int]] = Field(
+        serialization_alias="geRangePrefixLength", validation_alias="geRangePrefixLength"
+    )
 
 
 class IPv6PrefixListParcel(_ParcelBase):
     type_: Literal["ipv6-prefix"] = Field(default="ipv6-prefix", exclude=True)
     entries: List[IPv6PrefixListEntry] = Field(default=[], validation_alias=AliasPath("data", "entries"))
 
-    def add_prefix(self, ipv6_network: IPv6Network):
+    def add_prefix(self, ipv6_network: IPv6Interface, ge: Optional[int] = None, le: Optional[int] = None):
         self.entries.append(
             IPv6PrefixListEntry(
-                ipv6_address=as_global(ipv6_network.network_address),
-                ipv6_prefix_length=as_global(ipv6_network.prefixlen),
+                ipv6_address=as_global(ipv6_network.network.network_address),
+                ipv6_prefix_length=as_global(ipv6_network.network.prefixlen),
+                le_range_prefix_length=as_global(le) if le is not None else None,
+                ge_range_prefix_length=as_global(ge) if ge is not None else None,
             )
         )

--- a/catalystwan/models/configuration/feature_profile/sdwan/policy_object/policy/policer.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/policy_object/policy/policer.py
@@ -12,7 +12,7 @@ PolicerExceedAction = Literal[
 ]
 
 
-class PolicierEntry(BaseModel):
+class PolicerEntry(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     burst: Global[int]
     exceed: Global[PolicerExceedAction]
@@ -31,13 +31,13 @@ class PolicierEntry(BaseModel):
         return rate_str
 
 
-class PolicierParcel(_ParcelBase):
+class PolicerParcel(_ParcelBase):
     type_: Literal["policer"] = Field(default="policer", exclude=True)
-    entries: List[PolicierEntry] = Field(default=[], validation_alias=AliasPath("data", "entries"))
+    entries: List[PolicerEntry] = Field(default=[], validation_alias=AliasPath("data", "entries"))
 
     def add_entry(self, burst: int, exceed: PolicerExceedAction, rate: int):
         self.entries.append(
-            PolicierEntry(
+            PolicerEntry(
                 burst=as_global(burst),
                 exceed=as_global(exceed, PolicerExceedAction),
                 rate=as_global(rate),

--- a/catalystwan/models/configuration/feature_profile/sdwan/policy_object/policy/standard_community.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/policy_object/policy/standard_community.py
@@ -10,7 +10,7 @@ from catalystwan.models.common import WellKnownBGPCommunities
 
 class StandardCommunityEntry(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
-    standard_community: Global[WellKnownBGPCommunities] = Field(
+    standard_community: Global[str] = Field(
         serialization_alias="standardCommunity", validation_alias="standardCommunity"
     )
 
@@ -19,7 +19,11 @@ class StandardCommunityParcel(_ParcelBase):
     type_: Literal["standard-community"] = Field(default="standard-community", exclude=True)
     entries: List[StandardCommunityEntry] = Field(default=[], validation_alias=AliasPath("data", "entries"))
 
-    def add_community(self, standard_community: WellKnownBGPCommunities):
-        self.entries.append(
-            StandardCommunityEntry(standard_community=as_global(standard_community, WellKnownBGPCommunities))
-        )
+    def _add_community(self, standard_community: str):
+        self.entries.append(StandardCommunityEntry(standard_community=as_global(standard_community)))
+
+    def add_well_known_community(self, standard_community: WellKnownBGPCommunities):
+        self._add_community(standard_community)
+
+    def add_community(self, as_number: int, community_number: int) -> None:
+        self._add_community(f"{as_number}:{community_number}")

--- a/catalystwan/models/configuration/feature_profile/sdwan/policy_object/security/security_port.py
+++ b/catalystwan/models/configuration/feature_profile/sdwan/policy_object/security/security_port.py
@@ -32,5 +32,11 @@ class SecurityPortParcel(_ParcelBase):
     type_: Literal["security-port"] = Field(default="security-port", exclude=True)
     entries: List[SecurityPortListEntry] = Field(default=[], validation_alias=AliasPath("data", "entries"))
 
-    def add_port(self, port: str):
+    def _add_port(self, port: str):
         self.entries.append(SecurityPortListEntry(port=as_global(port)))
+
+    def add_port(self, port: int):
+        self._add_port(str(port))
+
+    def add_port_range(self, start_port: int, end_port: int):
+        self._add_port(f"{start_port}-{end_port}")

--- a/catalystwan/models/policy/centralized.py
+++ b/catalystwan/models/policy/centralized.py
@@ -228,7 +228,7 @@ class CentralizedPolicy(PolicyCreationPayload):
         # while POST /template/policy/vsmart requires a regular object
         # it makes sense to reuse that model for both requests and present parsed data to the user
         # TODO: this is workaround, probably it is better to provide separate models for "cli" and "feature"
-        if policy_definition := values.get("policyDefinition") and values.get("policyType") != "cli":
+        if (policy_definition := values.get("policyDefinition")) and values.get("policyType") != "cli":
             if isinstance(policy_definition, str):
                 values["policyDefinition"] = CentralizedPolicyDefinition.model_validate_json(policy_definition)
         else:

--- a/catalystwan/models/policy/lists.py
+++ b/catalystwan/models/policy/lists.py
@@ -264,7 +264,7 @@ class ClassMapList(PolicyListBase):
 
     def assign_queue(self, queue: int) -> None:
         # Class map list must have only one entry!
-        entry = ClassMapListEntry(queue=str(queue))
+        entry = ClassMapListEntry(queue=queue)
         self._add_entry(entry, single=True)
 
 

--- a/catalystwan/models/policy/lists.py
+++ b/catalystwan/models/policy/lists.py
@@ -8,6 +8,9 @@ from pydantic import BaseModel, Field
 
 from catalystwan.models.common import InterfaceType, TLOCColor, WellKnownBGPCommunities
 from catalystwan.models.configuration.feature_profile.sdwan.policy_object import AnyPolicyObjectParcel
+from catalystwan.models.configuration.feature_profile.sdwan.policy_object.policy.application_list import (
+    ApplicationListParcel,
+)
 from catalystwan.models.configuration.feature_profile.sdwan.policy_object.policy.data_prefix import (
     DataPrefixEntry,
     DataPrefixParcel,
@@ -172,6 +175,18 @@ class AppList(PolicyListBase):
 
     def add_app_family(self, app_family: str) -> None:
         self._add_entry(AppListEntry(app_family=app_family))
+
+    def to_policy_object_parcel(self) -> ApplicationListParcel:
+        parcel = ApplicationListParcel(
+            parcel_name=self.name,
+            parcel_description=self.description,
+        )
+        for entry in self.entries:
+            if entry.app is not None:
+                parcel.add_application(entry.app)
+            elif entry.app_family is not None:
+                parcel.add_application_family(entry.app_family)
+        return parcel
 
 
 class ColorList(PolicyListBase):

--- a/catalystwan/models/policy/lists_entries.py
+++ b/catalystwan/models/policy/lists_entries.py
@@ -6,7 +6,7 @@ from uuid import UUID
 
 from pydantic import BaseModel, ConfigDict, Field, IPvAnyAddress, field_validator, model_validator
 
-from catalystwan.models.common import InterfaceType, TLOCColor, check_fields_exclusive
+from catalystwan.models.common import InterfaceType, IntStr, TLOCColor, check_fields_exclusive
 
 
 def check_jitter_ms(jitter_str: Optional[str]) -> Optional[str]:
@@ -299,13 +299,7 @@ class ASPathListEntry(BaseModel):
 
 
 class ClassMapListEntry(BaseModel):
-    queue: str
-
-    @field_validator("queue")
-    @classmethod
-    def check_queue(cls, queue_str: str):
-        assert 0 <= int(queue_str) <= 7
-        return queue_str
+    queue: IntStr = Field(ge=0, le=7)
 
 
 class MirrorListEntry(BaseModel):

--- a/catalystwan/models/policy/policy.py
+++ b/catalystwan/models/policy/policy.py
@@ -47,6 +47,10 @@ class URLFilteringAssemblyItem(AssemblyItemBase):
     type: Literal["urlFiltering"] = "urlFiltering"
 
 
+class AdvancedInspectionProfileAssemblyItem(AssemblyItemBase):
+    type: Literal["advancedInspectionProfile"] = "advancedInspectionProfile"
+
+
 class AdvancedMalwareProtectionAssemblyItem(AssemblyItemBase):
     type: Literal["advancedMalwareProtection"] = "advancedMalwareProtection"
 

--- a/catalystwan/utils/config_migration/converters/policies/policy_lists.py
+++ b/catalystwan/utils/config_migration/converters/policies/policy_lists.py
@@ -80,11 +80,15 @@ def app_list(in_: AppList) -> ApplicationListParcel:
 
 def class_map(in_: ClassMapList) -> FowardingClassParcel:
     out = FowardingClassParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_queue(entry.queue)
     return out
 
 
 def color(in_: ColorList) -> ColorParcel:
     out = ColorParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_color(entry.color)
     return out
 
 

--- a/catalystwan/utils/config_migration/converters/policies/policy_lists.py
+++ b/catalystwan/utils/config_migration/converters/policies/policy_lists.py
@@ -1,0 +1,240 @@
+from typing import Any, Callable, Dict, List, Mapping, NamedTuple, Optional, Sequence, Type
+
+from catalystwan.models.configuration.feature_profile.sdwan.policy_object import (
+    AnyPolicyObjectParcel,
+    ApplicationListParcel,
+    AppProbeParcel,
+    ColorParcel,
+    DataPrefixParcel,
+    ExpandedCommunityParcel,
+    FowardingClassParcel,
+    FQDNDomainParcel,
+    GeoLocationListParcel,
+    IPSSignatureParcel,
+    IPv6DataPrefixParcel,
+    IPv6PrefixListParcel,
+    LocalDomainParcel,
+    PolicierParcel,
+    PreferredColorGroupParcel,
+    PrefixListParcel,
+    ProtocolListParcel,
+    SecurityPortParcel,
+    SecurityZoneListParcel,
+    SLAClassParcel,
+    StandardCommunityParcel,
+    TlocParcel,
+    URLAllowParcel,
+    URLBlockParcel,
+)
+from catalystwan.models.policy import (
+    AnyPolicyList,
+    AppList,
+    AppProbeClassList,
+    ClassMapList,
+    ColorList,
+    CommunityList,
+    DataIPv6PrefixList,
+    DataPrefixList,
+    ExpandedCommunityList,
+    FQDNList,
+    GeoLocationList,
+    IPSSignatureList,
+    IPv6PrefixList,
+    LocalDomainList,
+    PolicerList,
+    PortList,
+    PreferredColorGroupList,
+    PrefixList,
+    ProtocolNameList,
+    SLAClassList,
+    TLOCList,
+    URLAllowList,
+    URLBlockList,
+    ZoneList,
+)
+
+
+def _get_parcel_name_desc(policy_list: AnyPolicyList) -> Dict[str, Any]:
+    return dict(parcel_name=policy_list.name, parcel_description=policy_list.description)
+
+
+def app_probe(in_: AppProbeClassList) -> AppProbeParcel:
+    out = AppProbeParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_fowarding_class(entry.forwarding_class)
+    return out
+
+
+def app_list(in_: AppList) -> ApplicationListParcel:
+    out = ApplicationListParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        if entry.app is not None:
+            out.add_application(entry.app)
+        if entry.app_family is not None:
+            out.add_application_family(entry.app_family)
+    return out
+
+
+# TODO: def as_path(in_: ASPathList):
+
+
+def class_map(in_: ClassMapList) -> FowardingClassParcel:
+    out = FowardingClassParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def color(in_: ColorList) -> ColorParcel:
+    out = ColorParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def community(in_: CommunityList) -> StandardCommunityParcel:
+    out = StandardCommunityParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def data_prefix_ipv6(in_: DataIPv6PrefixList) -> IPv6DataPrefixParcel:
+    out = IPv6DataPrefixParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def data_prefix(in_: DataPrefixList) -> DataPrefixParcel:
+    out = DataPrefixParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def expanded_community(in_: ExpandedCommunityList) -> ExpandedCommunityParcel:
+    out = ExpandedCommunityParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def fqdn(in_: FQDNList) -> FQDNDomainParcel:
+    out = FQDNDomainParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def geo_location(in_: GeoLocationList) -> GeoLocationListParcel:
+    out = GeoLocationListParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def ips_signature(in_: IPSSignatureList) -> IPSSignatureParcel:
+    out = IPSSignatureParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def prefix_ipv6(in_: IPv6PrefixList) -> IPv6PrefixListParcel:
+    out = IPv6PrefixListParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+# TODO: def local_app(in_: LocalAppList):
+def local_domain(in_: LocalDomainList) -> LocalDomainParcel:
+    out = LocalDomainParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+# TODO: def mirror_list(in_: MirrorList):
+def policer(in_: PolicerList) -> PolicierParcel:
+    out = PolicierParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def port(in_: PortList) -> SecurityPortParcel:
+    out = SecurityPortParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def preferred_color_group(in_: PreferredColorGroupList) -> PreferredColorGroupParcel:
+    out = PreferredColorGroupParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def prefix(in_: PrefixList) -> PrefixListParcel:
+    out = PrefixListParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def protocol(in_: ProtocolNameList) -> ProtocolListParcel:
+    out = ProtocolListParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+# TODO: def region(in_: RegionList):
+# TODO: def site(in_: SiteList):
+def sla_class(in_: SLAClassList) -> SLAClassParcel:
+    out = SLAClassParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def tloc(in_: TLOCList) -> TlocParcel:
+    out = TlocParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def url_allow(in_: URLAllowList) -> URLAllowParcel:
+    out = URLAllowParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+def url_block(in_: URLBlockList) -> URLBlockParcel:
+    out = URLBlockParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+# TODO: def vpn(in_: VPNList):
+def zone(in_: ZoneList) -> SecurityZoneListParcel:
+    out = SecurityZoneListParcel(**_get_parcel_name_desc(in_))
+    return out
+
+
+Input = AnyPolicyList
+Output = AnyPolicyObjectParcel
+
+
+class ConvertAllResult(NamedTuple):
+    output: List[Output] = []
+    left: List[Input] = []
+
+
+CONVERTERS: Mapping[Type[Input], Callable[[Any], Output]] = {
+    AppProbeClassList: app_probe,
+    AppList: app_list,
+    ClassMapList: class_map,
+    ColorList: color,
+    CommunityList: community,
+    DataIPv6PrefixList: data_prefix_ipv6,
+    DataPrefixList: data_prefix,
+    ExpandedCommunityList: expanded_community,
+    FQDNList: fqdn,
+    GeoLocationList: geo_location,
+    IPSSignatureList: ips_signature,
+    IPv6PrefixList: prefix_ipv6,
+    LocalDomainList: local_domain,
+    PolicerList: policer,
+    PortList: port,
+    PreferredColorGroupList: preferred_color_group,
+    PrefixList: prefix,
+    ProtocolNameList: protocol,
+    SLAClassList: sla_class,
+    TLOCList: tloc,
+    URLAllowList: url_allow,
+    URLBlockList: url_block,
+    ZoneList: zone,
+}
+
+
+def convert(in_: Input) -> Optional[Output]:
+    if converter := CONVERTERS.get(type(in_)):
+        return converter(in_)
+    return None
+
+
+def convert_all(inputs: Sequence[Input]) -> ConvertAllResult:
+    result = ConvertAllResult()
+    for i in inputs:
+        if (output := convert(i)) and output is not None:
+            result.output.append(output)
+        else:
+            result.left.append(i)
+    return result

--- a/catalystwan/utils/config_migration/converters/policies/policy_lists.py
+++ b/catalystwan/utils/config_migration/converters/policies/policy_lists.py
@@ -94,6 +94,8 @@ def color(in_: ColorList) -> ColorParcel:
 
 def community(in_: CommunityList) -> StandardCommunityParcel:
     out = StandardCommunityParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out._add_community(entry.community)
     return out
 
 

--- a/catalystwan/utils/config_migration/converters/policy/policy_lists.py
+++ b/catalystwan/utils/config_migration/converters/policy/policy_lists.py
@@ -1,5 +1,6 @@
 from typing import Any, Callable, Dict, List, Mapping, NamedTuple, Optional, Sequence, Type
 
+from catalystwan.models.common import int_range_serializer
 from catalystwan.models.configuration.feature_profile.sdwan.policy_object import (
     AnyPolicyObjectParcel,
     ApplicationListParcel,
@@ -14,7 +15,7 @@ from catalystwan.models.configuration.feature_profile.sdwan.policy_object import
     IPv6DataPrefixParcel,
     IPv6PrefixListParcel,
     LocalDomainParcel,
-    PolicierParcel,
+    PolicerParcel,
     PreferredColorGroupParcel,
     PrefixListParcel,
     ProtocolListParcel,
@@ -76,8 +77,6 @@ def app_list(in_: AppList) -> ApplicationListParcel:
 
 
 # TODO: def as_path(in_: ASPathList):
-
-
 def class_map(in_: ClassMapList) -> FowardingClassParcel:
     out = FowardingClassParcel(**_get_parcel_name_desc(in_))
     for entry in in_.entries:
@@ -101,68 +100,108 @@ def community(in_: CommunityList) -> StandardCommunityParcel:
 
 def data_prefix_ipv6(in_: DataIPv6PrefixList) -> IPv6DataPrefixParcel:
     out = IPv6DataPrefixParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_prefix(entry.ipv6_prefix)
     return out
 
 
 def data_prefix(in_: DataPrefixList) -> DataPrefixParcel:
     out = DataPrefixParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_data_prefix(entry.ip_prefix)
     return out
 
 
 def expanded_community(in_: ExpandedCommunityList) -> ExpandedCommunityParcel:
     out = ExpandedCommunityParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_community(entry.community)
     return out
 
 
 def fqdn(in_: FQDNList) -> FQDNDomainParcel:
     out = FQDNDomainParcel(**_get_parcel_name_desc(in_))
+    out.from_fqdns([entry.pattern for entry in in_.entries])
     return out
 
 
 def geo_location(in_: GeoLocationList) -> GeoLocationListParcel:
     out = GeoLocationListParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        if entry.country is not None:
+            out.add_country(entry.country)
+        if entry.continent is not None:
+            out.add_continent(entry.continent)
     return out
 
 
 def ips_signature(in_: IPSSignatureList) -> IPSSignatureParcel:
     out = IPSSignatureParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_signature(f"{entry.generator_id}:{entry.signature_id}")
     return out
 
 
 def prefix_ipv6(in_: IPv6PrefixList) -> IPv6PrefixListParcel:
     out = IPv6PrefixListParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_prefix(ipv6_network=entry.ipv6_prefix, ge=entry.ge, le=entry.le)
     return out
 
 
 # TODO: def local_app(in_: LocalAppList):
 def local_domain(in_: LocalDomainList) -> LocalDomainParcel:
     out = LocalDomainParcel(**_get_parcel_name_desc(in_))
+    out.from_local_domains([entry.name_server for entry in in_.entries])
     return out
 
 
 # TODO: def mirror_list(in_: MirrorList):
-def policer(in_: PolicerList) -> PolicierParcel:
-    out = PolicierParcel(**_get_parcel_name_desc(in_))
+def policer(in_: PolicerList) -> PolicerParcel:
+    out = PolicerParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_entry(burst=entry.burst, exceed=entry.exceed, rate=entry.rate)
     return out
 
 
 def port(in_: PortList) -> SecurityPortParcel:
     out = SecurityPortParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out._add_port(int_range_serializer(entry.port))
     return out
 
 
 def preferred_color_group(in_: PreferredColorGroupList) -> PreferredColorGroupParcel:
     out = PreferredColorGroupParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_primary(
+            color_preference=list(entry.primary_preference.color_preference),
+            path_preference=entry.primary_preference.path_preference,
+        )
+        if entry.secondary_preference is not None:
+            out.add_secondary(
+                color_preference=list(entry.secondary_preference.color_preference),
+                path_preference=entry.secondary_preference.path_preference,
+            )
+        if entry.tertiary_preference is not None:
+            out.add_tertiary(
+                color_preference=list(entry.tertiary_preference.color_preference),
+                path_preference=entry.tertiary_preference.path_preference,
+            )
     return out
 
 
 def prefix(in_: PrefixList) -> PrefixListParcel:
     out = PrefixListParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_prefix(entry.ip_prefix)
     return out
 
 
 def protocol(in_: ProtocolNameList) -> ProtocolListParcel:
     out = ProtocolListParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_protocol(entry.protocol_name)
     return out
 
 
@@ -170,27 +209,39 @@ def protocol(in_: ProtocolNameList) -> ProtocolListParcel:
 # TODO: def site(in_: SiteList):
 def sla_class(in_: SLAClassList) -> SLAClassParcel:
     out = SLAClassParcel(**_get_parcel_name_desc(in_))
+    # TODO: requires app probe id
     return out
 
 
 def tloc(in_: TLOCList) -> TlocParcel:
     out = TlocParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_entry(tloc=entry.tloc, color=entry.color, encapsulation=entry.encap, preference=entry.preference)
     return out
 
 
 def url_allow(in_: URLAllowList) -> URLAllowParcel:
     out = URLAllowParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_url(entry.pattern)
     return out
 
 
 def url_block(in_: URLBlockList) -> URLBlockParcel:
     out = URLBlockParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        out.add_url(entry.pattern)
     return out
 
 
-# TODO: def vpn(in_: VPNList):
+# TODO: def vpn(in_: VPNList): needs to be converted to item from service profile
 def zone(in_: ZoneList) -> SecurityZoneListParcel:
     out = SecurityZoneListParcel(**_get_parcel_name_desc(in_))
+    for entry in in_.entries:
+        if entry.interface is not None:
+            out.add_interface(entry.interface)
+        if entry.vpn is not None:
+            out.add_vpn(int_range_serializer(entry.vpn))
     return out
 
 

--- a/catalystwan/workflows/config_migration.py
+++ b/catalystwan/workflows/config_migration.py
@@ -6,6 +6,7 @@ from catalystwan.endpoints.configuration_group import ConfigGroup
 from catalystwan.models.configuration.config_migration import UX1Config, UX2Config
 from catalystwan.session import ManagerSession
 from catalystwan.utils.config_migration.converters.feature_template import create_parcel_from_template
+from catalystwan.utils.config_migration.converters.policy.policy_lists import convert_all as convert_policy_lists
 from catalystwan.utils.config_migration.creators.config_group import ConfigGroupCreator
 
 logger = logging.getLogger(__name__)
@@ -52,9 +53,7 @@ def transform(ux1: UX1Config) -> UX2Config:
         if ft.template_type in SUPPORTED_TEMPLATE_TYPES:
             ux2.profile_parcels.append(create_parcel_from_template(ft))
     # Policy Lists
-    for policy_list in ux1.policies.policy_lists:
-        if (parcel := policy_list.to_policy_object_parcel()) is not None:
-            ux2.profile_parcels.append(parcel)
+    ux2.profile_parcels.extend(convert_policy_lists(ux1.policies.policy_lists).output)
     return ux2
 
 

--- a/catalystwan/workflows/config_migration.py
+++ b/catalystwan/workflows/config_migration.py
@@ -63,18 +63,12 @@ def collect_ux1_config(session: ManagerSession, progress: Callable[[str, int, in
 
     """Collect Policies"""
     policy_api = session.api.policy
-    progress("Collecting Policy Info", 0, 3)
 
-    centralized_policy_ids = [info.policy_id for info in policy_api.centralized.get()]
-    progress("Collecting Policy Info", 1, 3)
-
-    localized_policy_ids = [info.policy_id for info in policy_api.localized.get()]
-    progress("Collecting Policy Info", 2, 3)
-
+    progress("Collecting Policy Info", 0, 1)
     policy_definition_types_and_ids = [
         (policy_type, info.definition_id) for policy_type, info in policy_api.definitions.get_all()
     ]
-    progress("Collecting Policy Info", 3, 3)
+    progress("Collecting Policy Info", 1, 1)
 
     policy_list_types = POLICY_LIST_ENDPOINTS_MAP.keys()
     for i, policy_list_type in enumerate(policy_list_types):
@@ -85,13 +79,17 @@ def collect_ux1_config(session: ManagerSession, progress: Callable[[str, int, in
         ux1.policies.policy_definitions.append(policy_api.definitions.get(*type_and_id))
         progress("Collecting Policy Definitions", i + 1, len(policy_definition_types_and_ids))
 
-    for i, cpid in enumerate(centralized_policy_ids):
-        ux1.policies.centralized_policies.append(policy_api.centralized.get(id=cpid))
-        progress("Collecting Centralized Policies", i + 1, len(centralized_policy_ids))
+    progress("Collecting Centralized Policies", 0, 1)
+    ux1.policies.centralized_policies = [item for item in policy_api.centralized.get()]
+    progress("Collecting Centralized Policies", 1, 1)
 
-    for i, lpid in enumerate(localized_policy_ids):
-        ux1.policies.localized_policies.append(policy_api.localized.get(id=lpid))
-        progress("Collecting Localized Policies", i + 1, len(localized_policy_ids))
+    progress("Collecting Localized Policies", 0, 1)
+    ux1.policies.localized_policies = [item for item in policy_api.localized.get()]
+    progress("Collecting Localized Policies", 1, 1)
+
+    progress("Collecting Security Policies", 0, 1)
+    ux1.policies.security_policies = [item for item in policy_api.security.get()]
+    progress("Collecting Security Policies", 1, 1)
 
     """Collect Templates"""
     template_api = session.api.templates


### PR DESCRIPTION
1. Added converters:

    - AppProbeClassList: app_probe
    - AppList: app_list
    - ClassMapList: class_map
    - ColorList: color
    - CommunityList: community
    - DataIPv6PrefixList: data_prefix_ipv6
    - DataPrefixList: data_prefix
    - ExpandedCommunityList: expanded_community
    - FQDNList: fqdn
    - GeoLocationList: geo_location
    - IPSSignatureList: ips_signature
    - IPv6PrefixList: prefix_ipv6
    - LocalDomainList: local_domain
    - PolicerList: policer
    - PortList: port,
    - PreferredColorGroupList: preferred_color_group
    - PrefixList: prefix
    - ProtocolNameList: protocol,
    - SLAClassList: sla_class
    - TLOCList: tloc
    - URLAllowList: url_allow
    - URLBlockList: url_block
    - ZoneList: zone

2. Fixed models/validators when needed
3. Updated `transform()` method to use new converters
4. Updated `UX1Config` model so all policy items include both uuid and content of item
5. Updated `collect()` method so it collects Security Policies

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
