### PR TITLE
update deprecated github actions

### DIFF
--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -6,9 +6,9 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
     - name: Set Up Poetry
@@ -20,7 +20,7 @@ jobs:
     - name: Build HTML
       run: poetry run sphinx-build -M html docs/source docs/build
     - name: Upload artifacts
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: html-docs
         path: docs/build/html/

--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -19,9 +19,9 @@ jobs:
         run: |
             curl -fsSL https://deb.nodesource.com/setup_12.x | sudo -E bash -
             sudo apt-get install -y nodejs
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set Up Poetry

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,9 +17,9 @@ jobs:
         run: |
           curl -fsSL https://deb.nodesource.com/setup_12.x | sudo -E bash -
           sudo apt-get install -y nodejs
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Set Up Poetry

--- a/.github/workflows/unittests.yml
+++ b/.github/workflows/unittests.yml
@@ -19,9 +19,9 @@ jobs:
         run: |
             curl -fsSL https://deb.nodesource.com/setup_12.x | sudo -E bash -
             sudo apt-get install -y nodejs
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Set Up Poetry

--- a/.github/workflows/version.yml
+++ b/.github/workflows/version.yml
@@ -12,9 +12,9 @@ jobs:
         shell: bash
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: 3.8
       - name: Set Up Poetry

--- a/catalystwan/session.py
+++ b/catalystwan/session.py
@@ -259,7 +259,8 @@ class ManagerSession(ManagerResponseAdapter, APIEndpointClient):
         self.logger.info(
             f"Logged to vManage({self.platform_version}) as {self.username}. The session type is {self.session_type}"
         )
-        self.cookies.set("JSESSIONID", self.auth.set_cookie.get("JSESSIONID"))
+        if jsessionid := self.auth.set_cookie.get("JSESSIONID"):
+            self.cookies.set("JSESSIONID", jsessionid)
         return self
 
     def wait_server_ready(self, timeout: int, poll_period: int = 10) -> None:


### PR DESCRIPTION
# Pull Request summary:
Recently our Github actions giving a warning:
"Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/"

# Description of changes:
1. update github actions
2. fix typing error, not caught during pre-commit

# Checklist:
- [x] Make sure to run pre-commit before committing changes
- [x] Make sure all checks have passed
- [x] PR description is clear and comprehensive
- [x] Mentioned the issue that this PR solves (if applicable)
- [x] Make sure you test the changes
